### PR TITLE
Report failing position if parsing failed

### DIFF
--- a/src/main/generated/io/vertx/uritemplate/ExpandOptionsConverter.java
+++ b/src/main/generated/io/vertx/uritemplate/ExpandOptionsConverter.java
@@ -2,8 +2,6 @@ package io.vertx.uritemplate;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Converter and mapper for {@link io.vertx.uritemplate.ExpandOptions}.

--- a/src/main/java/io/vertx/uritemplate/impl/UriTemplateImpl.java
+++ b/src/main/java/io/vertx/uritemplate/impl/UriTemplateImpl.java
@@ -318,8 +318,9 @@ public class UriTemplateImpl implements UriTemplate {
 
     public UriTemplateImpl parseURITemplate(String s) {
       template = new UriTemplateImpl();
-      if (parseURITemplate(s, 0) != s.length()) {
-        throw new IllegalArgumentException();
+      int stop = parseURITemplate(s, 0);
+      if (stop != s.length()) {
+        throw new IllegalArgumentException("Error parsing template at position: " + stop);
       }
       for (Term term : template.terms) {
         if (term instanceof Expression && ((Expression) term).operator == Operator.FUTURE) {

--- a/src/test/java/io/vertx/tests/uritemplate/UriTemplateTest.java
+++ b/src/test/java/io/vertx/tests/uritemplate/UriTemplateTest.java
@@ -121,6 +121,17 @@ public class UriTemplateTest {
   }
 
   @Test
+  public void testInvalidCharacter() {
+    String template = "hello world";
+    try {
+      UriTemplate.of(template);
+      fail("Was expecting " + template + " to fail");
+    } catch (IllegalArgumentException ex) {
+      assertEquals("Error parsing template at position: 5", ex.getMessage());
+    }
+  }
+
+  @Test
   public void testOpReserved() {
     assertInvalidTemplate("{!test}");
   }


### PR DESCRIPTION
If parsing fails, UriTemplate now throws IllegalArgumentException without additional information.

The PR adds failed position to IllegalArgumentException message.
